### PR TITLE
Support fully-qualified domain name (instead of imgix.net subdomain)

### DIFF
--- a/lib/paperclip-imgix/source.rb
+++ b/lib/paperclip-imgix/source.rb
@@ -2,7 +2,7 @@ require 'digest/md5'
 
 module Paperclip::Imgix
   class Source
-    attr_reader :domain_name, :type
+    attr_reader :domain_name, :host_name, :type
 
     def self.canonical_type(type)
       type.to_s.downcase.tr('_', '').to_sym
@@ -14,13 +14,14 @@ module Paperclip::Imgix
 
     def self.create(opts)
       opts = opts.stringify_keys
-      if opts && !opts['domain_name'].blank? && valid_type?(opts['type'])
+      if opts && (!opts['domain_name'].blank? || !opts['host_name'].blank?) && valid_type?(opts['type'])
         new(opts)
       end
     end
 
     def initialize(options)
       @domain_name = options['domain_name']
+      @host_name = options['host_name']
       @type = self.class.canonical_type(options['type'])
       @secure_url_token = options['secure_url_token']
       @protocol = options['protocol'] || 'http'
@@ -74,7 +75,10 @@ module Paperclip::Imgix
           path << "&s=" << signature
         end
 
-        "#{@protocol}://#{@domain_name}.imgix.net#{path}"
+        # Use host name if provided. Otherwise use sub-domain name.
+        hostname = @host_name.blank? ? "#{@domain_name}.imgix.net" : @host_name
+
+        "#{@protocol}://#{hostname}#{path}"
       end
     end
 

--- a/lib/paperclip-imgix/source.rb
+++ b/lib/paperclip-imgix/source.rb
@@ -21,7 +21,7 @@ module Paperclip::Imgix
 
     def initialize(options)
       @domain_name = options['domain_name']
-      @host_name = options['host_name']
+      @hostnames = options['hostnames']
       @type = self.class.canonical_type(options['type'])
       @secure_url_token = options['secure_url_token']
       @protocol = options['protocol'] || 'http'
@@ -76,7 +76,11 @@ module Paperclip::Imgix
         end
 
         # Use host name if provided. Otherwise use sub-domain name.
-        hostname = @host_name.blank? ? "#{@domain_name}.imgix.net" : @host_name
+        if @hostnames.present?
+          hostname = @hostnames[path.hash % @hostnames.length]
+        else
+          hostname = "#{@domain_name}.imgix.net"
+        end
 
         "#{@protocol}://#{hostname}#{path}"
       end

--- a/lib/paperclip-imgix/style.rb
+++ b/lib/paperclip-imgix/style.rb
@@ -64,7 +64,7 @@ module Paperclip::Imgix
                           val = val.to_s if val.is_a?(Symbol)
                           val = val.split(',') if val.is_a?(String)
                           if val.is_a?(Array) && !val.empty?
-                            par[key] = (%w{format enchance redeye} & val).join(',')
+                            par[key] = (%w{format enhance redeye} & val).join(',')
                           end
                         end
                       end,

--- a/lib/paperclip-imgix/version.rb
+++ b/lib/paperclip-imgix/version.rb
@@ -1,5 +1,5 @@
 module Paperclip
   module Imgix
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end

--- a/lib/paperclip-imgix/version.rb
+++ b/lib/paperclip-imgix/version.rb
@@ -1,5 +1,5 @@
 module Paperclip
   module Imgix
-    VERSION = "0.1.2"
+    VERSION = "0.1.3"
   end
 end


### PR DESCRIPTION
Useful for CNAME support when sourcing images hosted by Imgix.

I left the domain_name setting in place for backwards compatibility, but wouldn't miss it if it were to disappear completely.
